### PR TITLE
Fix isDisabled always showing false

### DIFF
--- a/src/core/services/deployments-manager.ts
+++ b/src/core/services/deployments-manager.ts
@@ -153,7 +153,7 @@ class DeploymentsManager {
         }
         return {
             description: packageVersion.packageInfo.description,
-            isDisabled: false,
+            isDisabled: packageVersion.packageInfo.is_disabled === 1,
             isMandatory: packageVersion.packageInfo.is_mandatory === 1,
             rollout: 100,
             appVersion: packageVersion.deploymentsVersions.app_version,


### PR DESCRIPTION
When running `code-push deployment history`,  disabled packages are not marked as disabled